### PR TITLE
ref-cache: replace "FLEX_ALLOC_MEM" with "FELX_ALLOC_STR"

### DIFF
--- a/refs/files-backend.c
+++ b/refs/files-backend.c
@@ -242,7 +242,7 @@ static void add_per_worktree_entries_to_dir(struct ref_dir *dir, const char *dir
 		pos = search_ref_dir(dir, prefix, prefix_len);
 		if (pos >= 0)
 			continue;
-		child_entry = create_dir_entry(dir->cache, prefix, prefix_len);
+		child_entry = create_dir_entry(dir->cache, prefix);
 		add_entry_to_dir(dir, child_entry);
 	}
 }
@@ -326,8 +326,7 @@ static void loose_fill_ref_dir(struct ref_store *ref_store,
 		if (dtype == DT_DIR) {
 			strbuf_addch(&refname, '/');
 			add_entry_to_dir(dir,
-					 create_dir_entry(dir->cache, refname.buf,
-							  refname.len));
+					 create_dir_entry(dir->cache, refname.buf));
 		} else if (dtype == DT_REG) {
 			loose_fill_ref_dir_regular_file(refs, refname.buf, dir);
 		}
@@ -442,7 +441,7 @@ static struct ref_cache *get_loose_ref_cache(struct files_ref_store *refs,
 		 * Add an incomplete entry for "refs/" (to be filled
 		 * lazily):
 		 */
-		add_entry_to_dir(dir, create_dir_entry(refs->loose, "refs/", 5));
+		add_entry_to_dir(dir, create_dir_entry(refs->loose, "refs/"));
 	}
 	return refs->loose;
 }

--- a/refs/ref-cache.c
+++ b/refs/ref-cache.c
@@ -54,7 +54,7 @@ struct ref_cache *create_ref_cache(struct ref_store *refs,
 
 	ret->ref_store = refs;
 	ret->fill_ref_dir = fill_ref_dir;
-	ret->root = create_dir_entry(ret, "", 0);
+	ret->root = create_dir_entry(ret, "");
 	return ret;
 }
 
@@ -94,11 +94,11 @@ static void clear_ref_dir(struct ref_dir *dir)
 }
 
 struct ref_entry *create_dir_entry(struct ref_cache *cache,
-				   const char *dirname, size_t len)
+				   const char *dirname)
 {
 	struct ref_entry *direntry;
 
-	FLEX_ALLOC_MEM(direntry, name, dirname, len);
+	FLEX_ALLOC_STR(direntry, name, dirname);
 	direntry->u.subdir.cache = cache;
 	direntry->flag = REF_DIR | REF_INCOMPLETE;
 	return direntry;

--- a/refs/ref-cache.h
+++ b/refs/ref-cache.h
@@ -171,7 +171,7 @@ struct ref_dir *get_ref_dir(struct ref_entry *entry);
  * "refs/heads/") or "" for the top-level directory.
  */
 struct ref_entry *create_dir_entry(struct ref_cache *cache,
-				   const char *dirname, size_t len);
+				   const char *dirname);
 
 struct ref_entry *create_ref_entry(const char *refname,
 				   const char *referent,


### PR DESCRIPTION
We use "FLEX_ALLOC_MEM" macro to initialize the "name" string field of "struct ref_enrty" in "create_dir_entry" function. This macro needs the callers to explicitly specify the memory size. So, we let the callers pass the "len" to "create_dir_entry" function. However, when the callers use the raw string for "dirname", it's bad that the callers need to calculate the length of the raw string and pass the literal to the "create_dir_entry" function like the following shows:

  add_entry_to_dir(dir, create_dir_entry(refs->loose, "refs/", 5));

In "create_ref_entry", we use "FELX_ALLOC_STR" macro to create a "struct ref_entry *" for a loose ref. And we also return the "struct ref_enrty *" in "create_dir_entry" function, we'd better also align with this behavior.

Replace "FLEX_ALLOC_MEM" with "FELX_ALLOC_STR" in "create_dir_entry". Then, remove the "len" parameter in "create_dir_entry" function.

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

For a single-commit pull request, please *leave the pull request description
empty*: your commit message itself should describe your changes.

Please read the "guidelines for contributing" linked above!
